### PR TITLE
update dropout in lrcn model

### DIFF
--- a/models.py
+++ b/models.py
@@ -132,11 +132,22 @@ class ResearchModels():
         model.add(TimeDistributed(MaxPooling2D((2, 2), strides=(2, 2))))
 
         model.add(TimeDistributed(Flatten()))
-
+        
+        
+        ### option 1:
         model.add(Dropout(0.5))
+        model.add(LSTM(256, return_sequences=False, recurrent_dropout=0.5))
+        model.add(Dense(self.nb_classes, activation='softmax'))
+        
+        ### option 2:
         model.add(LSTM(256, return_sequences=False, dropout=0.5))
         model.add(Dense(self.nb_classes, activation='softmax'))
-
+        
+        ### option 3:
+        model.add(LSTM(256, return_sequences=False, dropout=0.5))
+        model.add(Dropout(0.5))
+        model.add(Dense(self.nb_classes, activation='softmax'))
+        
         return model
 
     def mlp(self):


### PR DESCRIPTION
I believe you are applying 0.5 dropout twice to your LSTM layer in the LRCN network, in effect applying 0.75 dropout, is that true?
(Excuse me if I'm wrong)

Depending on where we want to apply dropout, we can choose from several options.
This patch cannot be included directly, as one of the provided options has to be chosen.
Option 1 applies dropout to the LSTM input
Option 2 applies dropout to the LSTM input and to the recurrent/hidden input (in case that was the intention of the second written dropout)
Option 3 applies dropout to the LSTM input, as well as the subsequent FC layer, if that was the intention of the second written dropout)