### PR TITLE
modified source path of moving, so that it can find UCF-101 dataset

### DIFF
--- a/data/1_move_files.py
+++ b/data/1_move_files.py
@@ -55,14 +55,15 @@ def move_files(file_groups):
 
             # Check if we have already moved this file, or at least that it
             # exists to move.
-            if not os.path.exists(filename):
-                print("Can't find %s to move. Skipping." % (filename))
+            src = os.path.join("UCF-101", classname, filename)
+            if not os.path.exists(src):
+                print("Can't find %s to move. Skipping." % (src))
                 continue
 
             # Move it.
             dest = os.path.join(group, classname, filename)
-            print("Moving %s to %s" % (filename, dest))
-            os.rename(filename, dest)
+            print("Moving %s to %s" % (src, dest))
+            os.rename(src, dest)
 
     print("Done.")
 


### PR DESCRIPTION
Hi Matt Harvey,

In `1_move_files.py` , the filename is only the video file name. it doesn't contain the path of UCF dataset and classname path.  That is the reason that  when run it,  it returns "Can't find xxx to move. Skipping xxx." 
 
I modified 

```python
            if not os.path.exists(filename):
                print("Can't find %s to move. Skipping." % (filename))
                continue

            # Move it.
            dest = os.path.join(group, classname, filename)
            print("Moving %s to %s" % (filename, dest))
            os.rename(filename, dest)
```

to

```
            src = os.path.join("UCF-101", classname, filename)
            if not os.path.exists(src):
                print("Can't find %s to move. Skipping." % (src))
                continue

            # Move it.
            dest = os.path.join(group, classname, filename)
            print("Moving %s to %s" % (src, dest))
            os.rename(src, dest)
```

This way others don’t need to modify it again.